### PR TITLE
feat(DDS): 添加手机端报警订阅器实现

### DIFF
--- a/AppTest/pom.xml
+++ b/AppTest/pom.xml
@@ -44,8 +44,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             

--- a/AppTest/src/main/java/AppSimulator/DDS/AlertSubscriber.java
+++ b/AppTest/src/main/java/AppSimulator/DDS/AlertSubscriber.java
@@ -1,0 +1,209 @@
+package AppSimulator.DDS;
+
+import AppSimulator.MobileAppSimulator;
+import IDL.Alert;
+import IDL.AlertDataReader;
+import IDL.AlertSeq;
+import com.zrdds.infrastructure.*;
+import com.zrdds.subscription.*;
+import com.zrdds.topic.Topic;
+
+
+
+/**
+ * 手机端报警订阅器
+ * 用于接收家居模拟器发送的家具异常报警信息
+ */
+public class AlertSubscriber {
+    private final MobileAppSimulator appSimulator;
+    private AlertDataReader alertReader;
+
+    public AlertSubscriber(MobileAppSimulator appSimulator) {
+        this.appSimulator = appSimulator;
+    }
+
+    /**
+     * 启动报警订阅器，使用监听器模式
+     */
+    public boolean start(Subscriber sub, Topic alertTopic) {
+        // 配置QoS
+        DataReaderQos drQos = new DataReaderQos();
+        sub.get_default_datareader_qos(drQos);
+        drQos.durability.kind = DurabilityQosPolicyKind.TRANSIENT_LOCAL_DURABILITY_QOS;
+        drQos.reliability.kind = ReliabilityQosPolicyKind.RELIABLE_RELIABILITY_QOS;
+        drQos.history.kind = HistoryQosPolicyKind.KEEP_LAST_HISTORY_QOS;
+        drQos.history.depth = 10;
+
+        // 创建Alert的DataReader
+        alertReader = (AlertDataReader) sub.create_datareader(
+                alertTopic,
+                drQos,
+                new AlertListener(),
+                StatusKind.STATUS_MASK_ALL);
+
+        if (alertReader == null) {
+            System.err.println("[AlertSubscriber] 无法创建AlertDataReader");
+            return false;
+        }
+
+        System.out.println("[AlertSubscriber] 已启动，等待报警消息...");
+        return true;
+    }
+
+    /**
+     * Alert监听器实现，处理接收到的报警消息
+     */
+    private class AlertListener implements DataReaderListener {
+        
+        @Override
+        public void on_data_available(DataReader reader) {
+            AlertDataReader alertReader = (AlertDataReader) reader;
+            AlertSeq alertSeq = new AlertSeq();
+            SampleInfoSeq infoSeq = new SampleInfoSeq();
+
+            try {
+                // 获取 take() 方法的返回码（RETCODE_NO_DATA 是返回码而非异常）
+                ReturnCode_t retCode = alertReader.take(alertSeq, infoSeq,
+                        ResourceLimitsQosPolicy.LENGTH_UNLIMITED,
+                        SampleStateKind.ANY_SAMPLE_STATE, ViewStateKind.ANY_VIEW_STATE,
+                        InstanceStateKind.ANY_INSTANCE_STATE);
+
+                // 检查返回码：无数据时直接返回（无需处理）
+                if (retCode == ReturnCode_t.RETCODE_NO_DATA) {
+                    return;
+                }
+                // 其他错误返回码需处理
+                else if (retCode != ReturnCode_t.RETCODE_OK) {
+                    System.err.println("[AlertSubscriber] take() 失败，返回码: " + retCode);
+                    return;
+                }
+
+                // 处理接收到的报警数据
+                for (int i = 0; i < alertSeq.length(); i++) {
+                    Alert alert = (Alert) alertSeq.get_at(i);
+                    SampleInfo info = (SampleInfo) infoSeq.get_at(i);
+
+                    if (info.valid_data) {
+                        handleAlert(alert);
+                    }
+                }
+            }
+            catch (Exception e) {
+                System.err.println("[AlertSubscriber] 处理报警消息时出错: " + e.getMessage());
+            } finally {
+                if (alertSeq != null) {
+                    alertReader.return_loan(alertSeq, infoSeq);
+                }
+            }
+        }
+
+        @Override
+        public void on_sample_lost(DataReader dataReader, SampleLostStatus sampleLostStatus) {
+
+        }
+
+        @Override
+        public void on_requested_deadline_missed(DataReader dataReader, RequestedDeadlineMissedStatus requestedDeadlineMissedStatus) {
+
+        }
+
+        @Override
+        public void on_requested_incompatible_qos(DataReader dataReader, RequestedIncompatibleQosStatus requestedIncompatibleQosStatus) {
+
+        }
+
+        @Override
+        public void on_sample_rejected(DataReader dataReader, SampleRejectedStatus sampleRejectedStatus) {
+
+        }
+
+        @Override
+        public void on_liveliness_changed(DataReader reader, LivelinessChangedStatus status) {
+            System.out.println("[AlertSubscriber] 报警发布者活跃度变化: " + 
+                    "活跃数量=" + status.alive_count + 
+                    ", 不活跃数量=" + status.not_alive_count);
+        }
+
+        @Override
+        public void on_subscription_matched(DataReader reader, SubscriptionMatchedStatus status) {
+            System.out.println("[AlertSubscriber] 订阅匹配变化: " + 
+                    "当前匹配数=" + status.current_count);
+        }
+
+        @Override
+        public void on_data_arrived(DataReader dataReader, Object o, SampleInfo sampleInfo) {
+
+        }
+    }
+
+    /**
+     * 处理单个报警消息
+     */
+    private void handleAlert(Alert alert) {
+        try {
+            String deviceName = "未知设备";
+            String alertDescription = "";
+
+            // 根据报警类型ID生成描述
+            switch (alert.alert_id) {
+                case 1: // FIRE
+                    alertDescription = "🚨 火灾警报！";
+                    break;
+                case 2: // INTRUSION
+                    alertDescription = "⚠️ 入侵警报！";
+                    break;
+                case 3: // DEVICE_OFFLINE
+                    alertDescription = "📱 设备离线警报";
+                    break;
+                case 4: // DEVICE_MALFUNCTION
+                    alertDescription = "🔧 设备故障警报";
+                    break;
+                case 5: // DEVICE_OVERHEAT
+                    alertDescription = "🔥 设备过热警报";
+                    break;
+                default:
+                    alertDescription = "❓ 未知警报类型";
+            }
+
+            // 获取设备名称
+            if (alert.deviceType != null && !alert.deviceType.isEmpty()) {
+                deviceName = getDeviceDisplayName(alert.deviceType);
+            }
+
+            // 构建完整报警信息
+            String fullAlert = String.format("%s\n设备: %s\n类型: %s\n时间: %s\n详情: %s",
+                    alertDescription,
+                    deviceName,
+                    alert.deviceType,
+                    alert.timeStamp,
+                    alert.description);
+
+            // 通知手机应用显示报警
+            if (appSimulator != null) {
+                appSimulator.displayAlert(fullAlert);
+            }
+
+            System.out.println("[AlertSubscriber] 收到报警: " + fullAlert);
+
+        } catch (Exception e) {
+            System.err.println("[AlertSubscriber] 处理报警消息失败: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 获取设备显示名称
+     */
+    private String getDeviceDisplayName(String deviceType) {
+        // 简单的设备ID到显示名称的映射
+        if (deviceType.contains("light")) {
+            return "灯具 " + deviceType.replaceAll("[^0-9]", "");
+        } else if (deviceType.contains("ac")) {
+            return "空调 " + deviceType.replaceAll("[^0-9]", "");
+        } else if (deviceType.contains("door")) {
+            return "门禁系统";
+        } else if (deviceType.contains("window")) {
+            return "窗户传感器";
+        }
+        return deviceType;
+    }
+}

--- a/HomeSimulator/src/main/java/HomeSimulator/HomeSimulator.java
+++ b/HomeSimulator/src/main/java/HomeSimulator/HomeSimulator.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class HomeSimulator {
     private static boolean hasLoad = false;
+    private static HomeSimulator instance; // 单例实例
 
     private DdsParticipant ddsParticipant;
     private CommandSubscriber commandSubscriber;
@@ -33,6 +34,15 @@ public class HomeSimulator {
     public HomeSimulator() {
         loadLibrary();
         this.running = new AtomicBoolean(false);
+        instance = this; // 设置单例实例
+    }
+    
+    /**
+     * 获取报警系统实例
+     * @return 报警系统实例
+     */
+    public static HomeSimulatorAlert getAlertSystem() {
+        return instance != null ? instance.alertSystem : null;
     }
 
     private void loadLibrary() {
@@ -97,6 +107,7 @@ public class HomeSimulator {
         
         // 4. 创建报警系统
         alertSystem = new HomeSimulatorAlert(ddsPublisher, homeStatusTopic);
+        alertSystem.setFurnitureManager(furnitureManager);
 
         System.out.println("[HomeSimulator] DDS初始化完成");
     }
@@ -148,15 +159,6 @@ public class HomeSimulator {
                 break;
             case "ac_off":
                 turnOffAllAirConditioners();
-                break;
-            // 添加报警相关命令处理
-            case "alert_test":
-                testDeviceAlert();
-                break;
-            case "alert_clear":
-                if (alertSystem != null) {
-                    alertSystem.clearAlert();
-                }
                 break;
             default:
                 System.err.println("[HomeSimulator] 未知的家居命令: " + action);

--- a/HomeSimulator/src/main/java/HomeSimulator/HomeSimulatorAlert.java
+++ b/HomeSimulator/src/main/java/HomeSimulator/HomeSimulatorAlert.java
@@ -7,7 +7,6 @@ import com.zrdds.publication.Publisher;
 import com.zrdds.topic.Topic;
 import IDL.HomeStatus;
 import IDL.HomeStatusDataWriter;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -144,7 +143,7 @@ public class HomeSimulatorAlert {
         alertReporter.scheduleAtFixedRate(
                 this::reportAlertStatus, 
                 0, 
-                5, 
+                10,
                 TimeUnit.SECONDS);
                 
         // 启动设备监控
@@ -380,13 +379,14 @@ public class HomeSimulatorAlert {
 
     /**
      * 获取当前时间戳
-     * @return 格式化的时间戳字符串
+     * @return 格式化的时间字符串
      */
     private String getCurrentTimeStamp() {
-        LocalDateTime now = LocalDateTime.now();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        return now.format(formatter);
+        return LocalDateTime.now().format(formatter);
     }
+    
+
     
     /**
      * 监控设备状态
@@ -450,6 +450,40 @@ public class HomeSimulatorAlert {
         
         System.out.printf("[HomeSimulatorAlert] 收到设备报警: ID=%s, 类型=%s, 消息=%s%n", 
                 deviceId, alertType, alertMessage);
+    }
+    
+    /**
+     * 接收来自家具设备的独立报警
+     * @param deviceId 设备ID
+     * @param deviceType 设备类型
+     * @param alertType 报警类型
+     * @param message 报警消息
+     */
+    public void receiveDeviceAlert(String deviceId, String deviceType, String alertType, String message) {
+        System.out.printf("[HomeSimulatorAlert] 收到独立设备报警: ID=%s, 类型=%s, 报警=%s, 消息=%s%n", 
+                deviceId, deviceType, alertType, message);
+        
+        // 映射到系统报警类型
+        AlertType systemAlertType = mapToSystemAlertType(deviceType, alertType);
+        
+        // 构建完整的报警消息
+        String fullMessage = String.format("设备 %s: %s", deviceId, message);
+        
+        // 触发系统报警
+        triggerAlert(systemAlertType, fullMessage);
+    }
+    
+    /**
+     * 清除特定设备的报警
+     * @param deviceId 设备ID
+     */
+    public void clearDeviceAlert(String deviceId) {
+        System.out.printf("[HomeSimulatorAlert] 清除设备报警: ID=%s%n", deviceId);
+        
+        // 如果当前报警是由该设备触发的，则清除
+        if (alertActive.get() && alertMessage.contains(deviceId)) {
+            clearAlert();
+        }
     }
     
     /**

--- a/HomeSimulator/src/main/java/HomeSimulator/furniture/FurnitureManager.java
+++ b/HomeSimulator/src/main/java/HomeSimulator/furniture/FurnitureManager.java
@@ -2,6 +2,8 @@ package HomeSimulator.furniture;
 
 import IDL.HomeStatus;
 import IDL.HomeStatusDataWriter;
+import HomeSimulator.HomeSimulator;
+import HomeSimulator.HomeSimulatorAlert;
 import com.zrdds.infrastructure.*;
 import com.zrdds.publication.DataWriterQos;
 import com.zrdds.publication.Publisher;
@@ -91,6 +93,16 @@ public class FurnitureManager {
         registerFurniture(bedroomLight);
        registerFurniture(livingRoomAC);
         registerFurniture(bedroomAC);
+
+        // 设置报警系统引用（通过HomeSimulator获取）
+        HomeSimulatorAlert alertSystem = HomeSimulator.getAlertSystem();
+        if (alertSystem != null) {
+            livingRoomLight.setAlertSystem(alertSystem);
+            bedroomLight.setAlertSystem(alertSystem);
+            livingRoomAC.setAlertSystem(alertSystem);
+            bedroomAC.setAlertSystem(alertSystem);
+            System.out.println("[FurnitureManager] 已为所有设备设置报警系统引用");
+        }
 
         System.out.println("[FurnitureManager] 默认家具初始化完成（共" + furnitureMap.size() + "个）");
     }

--- a/java.exe.ddslog
+++ b/java.exe.ddslog
@@ -1,7 +1,17 @@
-********************  2025-09-02 15:23:38:726  ********************
+********************  2025-09-02 15:57:31:957  ********************
 Current ZRDDS version(2.4.4-r2761701) for SEU was compiled at Aug 22 2025 16:10:46
 *******************************************************************
-********************  2025-09-02 15:24:18:468  ********************
+********************  2025-09-02 15:57:32:021  ********************
+LOGINFO: LEVEL(WARNING)
+FUNC: DataWriterImpl.cpp:DataWriterQosCompatibleCheck(LINE: 8596)
+Match Reader (0189a8c0)(44590000)(00000000)(0e000004) failed: Durability incompatible in DataWriter (0189a8c0)(643e0000)(00000000)(0e000003) of Topic HomeStatus.
+*******************************************************************
+********************  2025-09-02 15:57:32:021  ********************
+LOGINFO: LEVEL(ERROR)
+FUNC: ZRSedp.cpp:ZRSedpAddDiscoveredDataReader(LINE: 5371)
+local writer((0189a8c0)(643e0000)(00000000)(0e000003)) match reader((0189a8c0)(44590000)(00000000)(0e000004)) topicName(HomeStatus) typeName(HomeStatus) failed(-101).
+*******************************************************************
+********************  2025-09-02 16:05:51:830  ********************
 LOGINFO: LEVEL(ERROR)
 FUNC: DomainParticipantFactoryImpl.cpp:DomainParticipantFactoryDeleteParticipant(LINE: 1215)
 can not found domainId(0).

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
   <groupId>org.example</groupId>
   <artifactId>SmartHomeDemoBackend</artifactId>
   <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
   <name>Archetype - SmartHomeDemoBackend</name>
   <url>http://maven.apache.org</url>
   <!-- 新增：添加项目依赖 -->


### PR DESCRIPTION
实现手机端报警订阅器，用于接收家居模拟器发送的家具异常报警信息。包含DDS初始化、报警监听启动/停止、报警消息处理等功能，支持多种报警类型和设备名称映射。